### PR TITLE
Move exception handling to GlobalException handler

### DIFF
--- a/src/main/java/info/toannvs/jobhunter/controller/UserController.java
+++ b/src/main/java/info/toannvs/jobhunter/controller/UserController.java
@@ -17,11 +17,6 @@ public class UserController {
         this.userService = userService;
     }
 
-    @ExceptionHandler(value = IdInvalidException.class)
-    public ResponseEntity<String> handleIdInvalidException(IdInvalidException e) {
-        return ResponseEntity.badRequest().body(e.getMessage());
-    }
-
     @GetMapping("/users/{id}")
     public ResponseEntity<User> getUserById(@PathVariable Long id) {
         User user = userService.handleGetUserById(id);

--- a/src/main/java/info/toannvs/jobhunter/exception/GlobalException.java
+++ b/src/main/java/info/toannvs/jobhunter/exception/GlobalException.java
@@ -1,0 +1,13 @@
+package info.toannvs.jobhunter.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalException {
+    @ExceptionHandler(value = IdInvalidException.class)
+    public ResponseEntity<String> handleIdInvalidException(IdInvalidException e) {
+        return ResponseEntity.badRequest().body(e.getMessage());
+    }
+}


### PR DESCRIPTION
- Removed exception handler from `UserController`
- Created `GlobalException` class to centralize exception handling
- Applied `@RestControllerAdvice` to handle `IdInvalidException` globally
- Improves maintainability and reusability of exception handling