### PR TITLE
Implement global API response formatting with FormatRestResponse

### DIFF
--- a/src/main/java/info/toannvs/jobhunter/util/FormatRestResponse.java
+++ b/src/main/java/info/toannvs/jobhunter/util/FormatRestResponse.java
@@ -1,0 +1,45 @@
+package info.toannvs.jobhunter.util;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+import jakarta.servlet.http.HttpServletResponse;
+import info.toannvs.jobhunter.domain.RestResponse;
+
+@ControllerAdvice
+public class FormatRestResponse implements ResponseBodyAdvice<Object> {
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class converterType) {
+        return true;
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body,
+                                  MethodParameter returnType,
+                                  MediaType selectedContentType,
+                                  Class selectedConverterType,
+                                  ServerHttpRequest request,
+                                  ServerHttpResponse response) {
+        HttpServletResponse servletResponse = ((ServletServerHttpResponse) response).getServletResponse();
+        int status = servletResponse.getStatus();
+
+        RestResponse<Object> res = new RestResponse<Object>();
+        res.setStatus(status);
+
+        if (status >= 400) {
+            return body;
+        } else {
+            res.setData(body);
+            res.setMessage("CALL API SUCCESS");
+        }
+
+        return res;
+    }
+
+}


### PR DESCRIPTION
- Added `FormatRestResponse` to wrap API responses in `RestResponse<T>`.
- Implements `ResponseBodyAdvice` to standardize response structure.
- Includes HTTP status and default success message: "CALL API SUCCESS".
- Bypasses formatting for error responses (status >= 400).