### PR TITLE
Enable Spring Security with basic configuration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ repositories {
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-//	implementation("org.springframework.boot:spring-boot-starter-security")
+	implementation("org.springframework.boot:spring-boot-starter-security")
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	developmentOnly("org.springframework.boot:spring-boot-devtools")
 	runtimeOnly("com.mysql:mysql-connector-j")

--- a/src/main/java/info/toannvs/jobhunter/config/SecurityConfiguration.java
+++ b/src/main/java/info/toannvs/jobhunter/config/SecurityConfiguration.java
@@ -1,0 +1,36 @@
+package info.toannvs.jobhunter.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableMethodSecurity(securedEnabled = true)
+public class SecurityConfiguration {
+
+    /**
+     * Password encoder
+     * @return
+     */
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            .authorizeHttpRequests(authorizeRequests ->
+                authorizeRequests
+                    .requestMatchers("/").permitAll()
+                    .anyRequest().authenticated()
+            )
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+        return http.build();
+    }
+}


### PR DESCRIPTION
- Un-commented `spring-boot-starter-security` dependency in `build.gradle.kts`.
- Added `SecurityConfiguration` class to configure security settings.
- Implemented:
  - BCrypt password encoder.
  - Stateless session management (JWT-ready).
  - Endpoint access control (root `/` is public, others require authentication).
- Enabled method-level security annotations (`@Secured`, `@PreAuthorize`).