### PR TITLE
Implement basic AuthController with login endpoint

### DIFF
--- a/src/main/java/info/toannvs/jobhunter/controller/AuthController.java
+++ b/src/main/java/info/toannvs/jobhunter/controller/AuthController.java
@@ -1,0 +1,26 @@
+package info.toannvs.jobhunter.controller;
+
+import info.toannvs.jobhunter.domain.dto.LoginDTO;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+public class AuthController {
+    private final AuthenticationManagerBuilder authenticationManagerBuilder;
+
+    public AuthController(AuthenticationManagerBuilder authenticationManagerBuilder) {
+        this.authenticationManagerBuilder = authenticationManagerBuilder;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<LoginDTO> login(@RequestBody LoginDTO loginDTO) {
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(loginDTO.getUsername(), loginDTO.getPassword());
+
+        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+        return ResponseEntity.ok().body(loginDTO);
+    }
+
+}


### PR DESCRIPTION
- Created `AuthController` to handle authentication requests.
- Added `/login` POST endpoint accepting `LoginDTO` (username/password).
- Used `AuthenticationManagerBuilder` to perform authentication.
- Currently returns the loginDTO on success (token generation to be added later).