### PR TITLE
Add SecurityUtil for JWT token generation

### DIFF
--- a/src/main/java/info/toannvs/jobhunter/util/SecurityUtil.java
+++ b/src/main/java/info/toannvs/jobhunter/util/SecurityUtil.java
@@ -1,0 +1,46 @@
+package info.toannvs.jobhunter.util;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.JwsHeader;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+public class SecurityUtil {
+
+    private final JwtEncoder jwtEncoder;
+
+    public SecurityUtil(JwtEncoder jwtEncoder) {
+        this.jwtEncoder = jwtEncoder;
+    }
+
+    public static final MacAlgorithm JWT_ALGORITHM = MacAlgorithm.HS512;
+
+    @Value("${hoidanit.jwt.base64-secret}")
+    private String jwtKey;
+
+    @Value("${hoidanit.jwt.token-validity-in-seconds}")
+    private long jwtExpiration;
+
+    public String createToken(Authentication authentication) {
+        Instant now = Instant.now();
+        Instant validity = now.plus(this.jwtExpiration, ChronoUnit.SECONDS);
+
+        // @formatter:off
+        JwtClaimsSet claims = JwtClaimsSet.builder()
+                .issuedAt(now)
+                .expiresAt(validity)
+                .subject(authentication.getName())
+                .claim("hoidanit", authentication)
+                .build();
+
+        JwsHeader jwsHeader = JwsHeader.with(JWT_ALGORITHM).build();
+        return this.jwtEncoder.encode(JwtEncoderParameters.from(jwsHeader, claims)).getTokenValue();
+
+    }
+}


### PR DESCRIPTION
- Introduced `SecurityUtil` utility class to encapsulate JWT creation logic.
- Uses `JwtEncoder` to generate tokens based on authenticated user.
- Reads secret and expiration from application properties.
- Supports HS512 (HMAC) algorithm via `MacAlgorithm.HS512`.