### PR TITLE
Add JWT configuration and encoder setup

### DIFF
--- a/src/main/java/info/toannvs/jobhunter/config/SecurityConfiguration.java
+++ b/src/main/java/info/toannvs/jobhunter/config/SecurityConfiguration.java
@@ -1,5 +1,9 @@
 package info.toannvs.jobhunter.config;
 
+import com.nimbusds.jose.jwk.source.ImmutableSecret;
+import com.nimbusds.jose.util.Base64;
+import info.toannvs.jobhunter.util.SecurityUtil;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
@@ -7,11 +11,19 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.NimbusJwtEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
 
 @Configuration
 @EnableMethodSecurity(securedEnabled = true)
 public class SecurityConfiguration {
+
+    @Value("${toannvs.jwt.base64-secret}")
+    private String jwtKey;
 
     /**
      * Password encoder
@@ -32,5 +44,15 @@ public class SecurityConfiguration {
                 .formLogin(f -> f.disable())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
         return http.build();
+    }
+
+    @Bean
+    public JwtEncoder jwtEncoder() {
+        return new NimbusJwtEncoder(new ImmutableSecret<>(getSecretKey()));
+    }
+
+    private SecretKey getSecretKey() {
+        byte[] keyBytes = Base64.from(jwtKey).decode();
+        return new SecretKeySpec(keyBytes, 0, keyBytes.length, SecurityUtil.JWT_ALGORITHM.getName());
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -9,3 +9,7 @@ spring.datasource.password=root123456
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.show-sql: true
 ###
+
+# Config JWT
+toannvs.jwt.base64-secret=TRrx3ZoD9xgevlM73MU8/ay9VO+8RJ7NjvFh5Ab0xoTsKzuPYwCOKDZugGYsVxroYRfP94DH6jBxBhFyBPaQQQ==
+toannvs.jwt.expiration=86400


### PR DESCRIPTION
- Defined JWT secret and expiration time in `application.properties`.
- Added `JwtEncoder` bean using `NimbusJwtEncoder` and HMAC HS512 algorithm.
- Updated `SecurityConfiguration` to generate `SecretKey` from base64 secret.
- Fixed typo in property placeholder (`$toannvs.jwt.base64-secret` → `${toannvs.jwt.base64-secret}`).